### PR TITLE
Updated Celeste version to 1.4

### DIFF
--- a/src/fr/guide/apps/celeste.md
+++ b/src/fr/guide/apps/celeste.md
@@ -14,6 +14,7 @@ Les versions officielles sont disponibles sur [GitHub Releases](https://github.c
 
 Si vous préférez, vous pouvez télécharger Celeste depuis ce lien :
 
+- [Celeste v1.4](https://yaya-cout.github.io/Nwagyu/assets/apps/celeste-1.4.nwa), réglage de bugs
 - [Celeste v1.3.1](https://yaya-cout.github.io/Nwagyu/assets/apps/celeste-1.3.1.nwa), nouvelle icône
 - [Celeste v1.3](https://yaya-cout.github.io/Nwagyu/assets/apps/celeste-1.3.nwa), support des sauvegardes
 - [Celeste v1.2](https://yaya-cout.github.io/Nwagyu/assets/apps/celeste-1.2.nwa), meilleure performance, limiteur d'images

--- a/src/guide/apps/celeste.md
+++ b/src/guide/apps/celeste.md
@@ -14,6 +14,7 @@ Official releases are available on [GitHub Releases](https://github.com/Benchato
 
 If you prefer, you can download Celeste from this link:
 
+- [Celeste v1.4](https://yaya-cout.github.io/Nwagyu/assets/apps/celeste-1.4.nwa), bug fixes
 - [Celeste v1.3.1](https://yaya-cout.github.io/Nwagyu/assets/apps/celeste-1.3.1.nwa), new icon
 - [Celeste v1.3](https://yaya-cout.github.io/Nwagyu/assets/apps/celeste-1.3.nwa), save support
 - [Celeste v1.2](https://yaya-cout.github.io/Nwagyu/assets/apps/celeste-1.2.nwa), improved performance, frame limiter


### PR DESCRIPTION
Very basic stuff, simply added an entry to the page for the 1.4 release of Celeste-Numworks on the english and french pages. I don't know how to add the .nwa to the assets folder tho so the links are dead links until the updated .nwa is put there. [The new .nwa is here](https://github.com/BenchatonDev/Celeste-Numworks/releases/download/1.4/Celeste.nwa)